### PR TITLE
Update default solr version.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,6 +5,6 @@
 # Copyright 2013, David Radcliffe
 #
 
-default['solr']['version']  = '4.5.1'
+default['solr']['version']  = '4.6.1'
 default['solr']['url']      = "http://apache.mirrors.lucidnetworks.net/lucene/solr/#{node['solr']['version']}/solr-#{node['solr']['version']}.tgz"
 default['solr']['data_dir'] = '/etc/solr'


### PR DESCRIPTION
The solr version 4.5.1 is no longer available via the provided URL.
