### PR TITLE
Add debian support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Installs [solr](http://lucene.apache.org/solr/) and starts the service.
 - `node['solr']['version']` - Version of solr to install
 - `node['solr']['url']` - Url of solr source to download
 - `node['solr']['data_dir']` - Location for solr data and config
+- `node['solr']['dir']` - Location of the solr sorce files
+- `node['solr']['port']` - The port the Solr service is bound to
 
 
 ## License and Author

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -8,3 +8,5 @@
 default['solr']['version']  = '4.5.1'
 default['solr']['url']      = "http://apache.mirrors.lucidnetworks.net/lucene/solr/#{node['solr']['version']}/solr-#{node['solr']['version']}.tgz"
 default['solr']['data_dir'] = '/etc/solr'
+default['solr']['dir'] = '/opt/solr'
+default['solr']['port'] = '8984'

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,5 +8,8 @@ version          '0.1.0'
 
 supports 'redhat'
 supports 'centos'
+supports 'debian'
+supports 'ubuntu'
 
 depends 'java'
+depends 'ark'

--- a/templates/default/initd.debian.erb
+++ b/templates/default/initd.debian.erb
@@ -1,0 +1,114 @@
+#! /bin/sh
+
+### BEGIN INIT INFO
+# Provides:          solr
+# Required-Start:    $local_fs $remote_fs
+# Required-Stop:     $local_fs $remote_fs
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Start/stop solr
+# Description:       Start/stop solr
+### END INIT INFO
+
+PATH=/sbin:/usr/sbin:/bin:/usr/bin
+SOLR_HOME=<%= @solr_home %>
+SOLR_DIR=<%= @solr_dir %>/example
+PORT=<%= @port %>
+PIDFILE=<%= @pid_file %>
+LOGFIlE=<%= @log_file %>
+DESC="Indexing server"
+NAME=solr
+DAEMON=/usr/bin/java
+DAEMON_ARGS="-Xms128M -Xmx512M -Dsolr.solr.home=$SOLR_HOME -Djetty.port=$PORT -jar start.jar"
+SCRIPTNAME=/etc/init.d/$NAME
+
+# Exit gracefully if the package is not installed
+[ -x "$DAEMON" ] || exit 0
+
+# Load the VERBOSE setting and other rcS variables
+. /lib/init/vars.sh
+
+# Define LSB log_* functions.
+# Depend on lsb-base (>= 3.2-14) to ensure that this file is present
+# and status_of_proc is working.
+. /lib/lsb/init-functions
+
+#
+# Function that starts the daemon/service
+#
+do_start()
+{
+  # Return
+  #   0 if daemon has been started
+  #   1 if daemon was already running
+  #   2 if daemon could not be started
+  start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON --test -- $DAEMON_ARGS > /dev/null \
+    || return 1
+  start-stop-daemon --start --quiet --pidfile $PIDFILE --chdir $SOLR_DIR --background --make-pidfile --exec $DAEMON -- \
+    $DAEMON_ARGS \
+    || return 2
+  sleep 2
+}
+
+#
+# Function that stops the daemon/service
+#
+do_stop()
+{
+  # Return
+  #   0 if daemon has been stopped
+  #   1 if daemon was already stopped
+  #   2 if daemon could not be stopped
+  #   other if a failure occurred
+  start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile $PIDFILE
+  RETVAL="$?"
+  [ "$RETVAL" = 2 ] && return 2
+  rm -f $PIDFILE
+  return "$RETVAL"
+}
+
+case "$1" in
+  start)
+  [ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC" "$NAME"
+  do_start
+  case "$?" in
+    0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+    2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+  esac
+  ;;
+  stop)
+  [ "$VERBOSE" != no ] && log_daemon_msg "Stopping $DESC" "$NAME"
+  do_stop
+  case "$?" in
+    0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+    2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+  esac
+  ;;
+  status)
+       status_of_proc "$DAEMON" "$NAME" && exit 0 || exit $?
+       ;;
+  restart|force-reload)
+  log_daemon_msg "Restarting $DESC" "$NAME"
+  do_stop
+  case "$?" in
+    0|1)
+    do_start
+    case "$?" in
+      0) log_end_msg 0 ;;
+      1) log_end_msg 1 ;; # Old process is still running
+      *) log_end_msg 1 ;; # Failed to start
+    esac
+    ;;
+    *)
+      # Failed to stop
+    log_end_msg 1
+    ;;
+  esac
+  ;;
+  *)
+  echo "Usage: $SCRIPTNAME {start|stop|status|restart|force-reload}" >&2
+  exit 3
+  ;;
+esac
+
+:

--- a/templates/default/initd.erb
+++ b/templates/default/initd.erb
@@ -13,13 +13,13 @@
 # source function library
 . /etc/rc.d/init.d/functions
 
-PIDFILE=/var/run/solr.pid
+PIDFILE=<%= @pid_file =%>
 
-LOG_FILE=/var/log/solr.log
+LOG_FILE=<%= @log_file =%>
 
 NAME="Solr"
 
-DESC="start/stop Solr Server"
+DESC="Solr Indexing Server"
 
 start() {
     if [ -f $PIDFILE ]; then

--- a/templates/default/solr.start.erb
+++ b/templates/default/solr.start.erb
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 cd <%= @solr_dir %>/example
-COMMAND="java -Xms128M -Xmx512M -Dsolr.solr.home=<%= @solr_home %> -Djetty.port=8984 -jar start.jar"
+COMMAND="java -Xms128M -Xmx512M -Dsolr.solr.home=<%= @solr_home %> -Djetty.port=<%= @port %> -jar start.jar"
 nohup $COMMAND > <%= @log_file %> 2>&1 &
 echo $! > <%= @pid_file %>
 exit $?


### PR DESCRIPTION
This PR adds a  template init.d script that is specific to debian
systems.  (Tested on Ubuntu Precise64)

---

This PR also makes the following minor changes.
-  It defines a `port` attribute.
  - So that users can override what port the service is bound to.
-  It defines a `dir` attribute.
  -  So that users can change where the solr src files are saved to.
- It replaces the `remote_file src_filpath` and `bash unpack_solr`
  calls with one call to `ark` (which is maintained by opscode).
  - This change has 3 advantages.
    - It reduces two calls to one making the code easier to reason about and maintain.
    - It leverages the Opscode maintainers by using a cookbook that they
      maintain. https://github.com/opscode-cookbooks/ark
    - It makes it so that sources gets extracted in a more semantic
      way.
      - On my system the solr files where being saved to
        `/opt/solr-4.6.1/solr-4.6.1/...` which I don't think is what was
        intended.
