### PR TITLE
Fixed problem where solr install path becomes /opt/solr-4.6.1/solr-4.6.1/

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,7 +20,7 @@ bash 'unpack_solr' do
   cwd ::File.dirname(src_filepath)
   code <<-EOH
     mkdir -p #{extract_path}
-    tar xzf #{src_filename} -C #{extract_path}
+    tar xzf #{src_filename} -C #{extract_path} --strip 1
   EOH
   not_if { ::File.exists?(extract_path) }
 end


### PR DESCRIPTION
The cookbook tries to untar the contents of the Apache Solr tgz files into a directory that it creates like: /opt/solr-4.6.1/ 

However, the tgz root contains this folder as well meaning that everything is installed into:
/opt/solr-4.6.1/solr-4.6.1/

Using tar with the --strip 1 option avoids this and means that the scripts can then find the solr binaries etc.
