### PR TITLE
Add configuration attribute for JVM options

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -13,3 +13,4 @@ default['solr']['port']     = '8984'
 default['solr']['pid_file'] = '/var/run/solr.pid'
 default['solr']['log_file'] = '/var/log/solr.log'
 default['solr']['install_java'] = true
+default['solr']['java_options'] = '-Xms128M -Xmx512M'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -44,7 +44,8 @@ template '/var/lib/solr.start' do
     :solr_home => node['solr']['data_dir'],
     :port => node['solr']['port'],
     :pid_file => node['solr']['pid_file'],
-    :log_file => node['solr']['log_file']
+    :log_file => node['solr']['log_file'],
+    :java_options => node['solr']['java_options']
   )
   only_if { !platform_family?('debian') }
 end
@@ -59,7 +60,8 @@ template '/etc/init.d/solr' do
     :solr_home => node['solr']['data_dir'],
     :port => node['solr']['port'],
     :pid_file => node['solr']['pid_file'],
-    :log_file => node['solr']['log_file']
+    :log_file => node['solr']['log_file'],
+	:java_options => node['solr']['java_options']
   )
 end
 

--- a/templates/default/initd.debian.erb
+++ b/templates/default/initd.debian.erb
@@ -16,10 +16,11 @@ SOLR_DIR=<%= @solr_dir %>/example
 PORT=<%= @port %>
 PIDFILE=<%= @pid_file %>
 LOGFIlE=<%= @log_file %>
+JAVA_OPTS=<%= @java_options %>
 DESC="start/stop Solr Server"
 NAME=solr
 DAEMON=/usr/bin/java
-DAEMON_ARGS="-Xms128M -Xmx512M -Dsolr.solr.home=$SOLR_HOME -Djetty.port=$PORT -jar start.jar"
+DAEMON_ARGS="$JAVA_OPTS -Dsolr.solr.home=$SOLR_HOME -Djetty.port=$PORT -jar start.jar"
 SCRIPTNAME=/etc/init.d/$NAME
 
 # Exit gracefully if the package is not installed

--- a/templates/default/solr.start.erb
+++ b/templates/default/solr.start.erb
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 cd <%= @solr_dir %>/example
-COMMAND="java -Xms128M -Xmx512M -Dsolr.solr.home=<%= @solr_home %> -Djetty.port=<%= @port %> -jar start.jar"
+COMMAND="java <%= @java_options %> -Dsolr.solr.home=<%= @solr_home %> -Djetty.port=<%= @port %> -jar start.jar"
 nohup $COMMAND > <%= @log_file %> 2>&1 &
 echo $! > <%= @pid_file %>
 exit $?


### PR DESCRIPTION
Add a new configuration attribute 'java_options' for passing options to
the JVM that were previously hardcoded in the startup script templates.

Signed-off-by: Gregor Zurowski <gregor@zurowski.org>