### PR TITLE
[templates] debian init.d - fix java_opts to string to cover space

### DIFF
--- a/templates/default/initd.debian.erb
+++ b/templates/default/initd.debian.erb
@@ -17,7 +17,7 @@ PORT=<%= @port %>
 PIDFILE=<%= @pid_file %>
 LOGFIlE=<%= @log_file %>
 USER=<%= @user %>
-JAVA_OPTS=<%= @java_options %>
+JAVA_OPTS="<%= @java_options %>"
 DESC="start/stop Solr Server"
 NAME=solr
 DAEMON=/usr/bin/java


### PR DESCRIPTION
The new java_opts in debian init template is broken, as it does not quote a value with space:
JAVA_OPTS=-Xms128M -Xmx512M

This results in the combined daemon args missing -Xmx512M which actually throws an error.

This fixes the output to this, which passes -Xmx512M along to daemon args and resolves error.
JAVA_OPTS="-Xms128M -Xmx512M"

