### PR TITLE
Patch to handle version <4.x and >=4.x

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,7 +6,7 @@
 #
 
 default['solr']['version']  = '4.6.1'
-default['solr']['url']      = "https://archive.apache.org/dist/lucene/solr/#{node['solr']['version']}/solr-#{node['solr']['version']}.tgz"
+default['solr']['url']      = "https://archive.apache.org/dist/lucene/solr/#{node['solr']['version']}/#{if node['solr']['version'].split(".")[0].to_i< 4 then "apache-" end}solr-#{node['solr']['version']}.tgz"
 default['solr']['data_dir'] = '/etc/solr'
 default['solr']['dir']      = '/opt/solr'
 default['solr']['port']     = '8984'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,7 +6,7 @@
 #
 
 default['solr']['version']  = '4.6.1'
-default['solr']['url']      = "https://archive.apache.org/dist/lucene/solr/#{node['solr']['version']}/#{if node['solr']['version'].split(".")[0].to_i< 4 then "apache-" end}solr-#{node['solr']['version']}.tgz"
+default['solr']['url']      = "https://archive.apache.org/dist/lucene/solr/#{node['solr']['version']}/#{ node['solr']['version'].split('.')[0].to_i < 4 ? 'apache-' : ''}solr-#{node['solr']['version']}.tgz"
 default['solr']['data_dir'] = '/etc/solr'
 default['solr']['dir']      = '/opt/solr'
 default['solr']['port']     = '8984'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,7 +6,7 @@
 #
 
 default['solr']['version']  = '4.6.1'
-default['solr']['url']      = "https://archive.apache.org/dist/lucene/solr/#{node['solr']['version']}/#{ node['solr']['version'].split('.')[0].to_i < 4 ? 'apache-' : ''}solr-#{node['solr']['version']}.tgz"
+default['solr']['url']      = "https://archive.apache.org/dist/lucene/solr/#{node['solr']['version']}/#{node['solr']['version'].split('.')[0].to_i < 4 ? 'apache-' : ''}solr-#{node['solr']['version']}.tgz"
 default['solr']['data_dir'] = '/etc/solr'
 default['solr']['dir']      = '/opt/solr'
 default['solr']['port']     = '8984'


### PR DESCRIPTION
This modification makes the cookbook to generate the default attributes properly. There was a change in the naming conventions of the Solr installer files. (Issue #9 )
It should work for all the currently available versions. Tested for 3.6.X and 4.10.0.