### PR TITLE
fix long_description for better tooling integration

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer       'David Radcliffe'
 maintainer_email 'radcliffe.david@gmail.com'
 license          'MIT'
 description      'Installs the solr search engine.'
-long_description 'See README.md'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.4.0'
 
 supports 'amazon'


### PR DESCRIPTION
Trivial change, but this pattern has become pretty common.

Some tooling will will render `long_description` to the user, so expanding to the actual documentation is useful.