### PR TITLE
Create the solr user and group.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -13,6 +13,21 @@ end
 extract_path = "#{node['solr']['dir']}-#{node['solr']['version']}"
 solr_path = "#{extract_path}/#{node['solr']['version'].split('.')[0].to_i < 5 ? 'example' : 'server'}"
 
+user node['solr']['user'] do
+  comment 'User that owns the solr data dir.'
+  home node['solr']['data_dir']
+  system true
+  shell '/bin/false'
+  only_if { node['solr']['user'] != 'root' }
+end
+
+group node['solr']['group'] do
+  members node['solr']['user']
+  append true
+  system true
+  only_if { node['solr']['group'] != 'root' }
+end
+
 ark 'solr' do
   url node['solr']['url']
   version node['solr']['version']


### PR DESCRIPTION
It is possible to override the user and group that own the solr data dir. To
prevent fatal errors when creating the data directory because the user doesn't
exists create the user and group first.

Refs: #30
